### PR TITLE
C10600 mailto redirect

### DIFF
--- a/rullion/master.js
+++ b/rullion/master.js
@@ -727,6 +727,9 @@ y.getRedirectURL = function (data_back, query_string) {
     if (query_string.indexOf(".html") > -1) {
         return query_string;
     }
+    if (query_string.indexOf("mailto") === 0) {
+        return query_string;
+    }
     if (query_string && query_string.indexOf("?") !== 0) {
         query_string = "?" + query_string;
     }


### PR DESCRIPTION
In binding site, we were getting a problem where mailtos which did not include ".html" (which was all social media links in binding site) were non-functional. This change should fix the problem.